### PR TITLE
Add new engineering ladder links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,36 @@ A collection of engineering career ladders for reference and inspiration.
 - [Axelerant](https://www.axelerant.com/blog/how-to-design-an-effective-career-ladder-for-engineers)
 - [Basecamp](https://github.com/basecamp/handbook/blob/master/titles-for-programmers.md)
 - [Buffer](https://buffer.com/resources/engineering-career-framework/)
+- [Capgemini](https://capgemini.github.io/grade-ladder/)
 - [Carta](https://medium.com/building-carta/engineering-levels-at-carta-d33db2a55a20)
 - [CircleCI](https://circleci.com/blog/why-we-re-designed-our-engineering-career-paths-at-circleci/)
 - [Dropbox](https://dropbox.github.io/dbx-career-framework/)
 - [Envoy](https://github.com/envoy/Engineering/blob/master/engineering_bands.md)
 - [Etsy](https://etsy.github.io/Etsy-Engineering-Career-Ladder/)
+- [Financial Times](https://github.com/Financial-Times/engineering-progression)
+- [Fog Creek](https://www.joelonsoftware.com/2009/02/13/fog-creek-professional-ladder/)
+- [Foursquare](https://foursquare.com/resources/blog/developer/engineering-levels-and-progression/)
 - [GitLab](https://handbook.gitlab.com/handbook/engineering/careers/matrix/)
 - [Glossier](https://medium.com/glossier/building-an-engineering-ladder-at-glossier-e7fc3a390695)
-- [Fog Creek](https://www.joelonsoftware.com/2009/02/13/fog-creek-professional-ladder/)
+- [Honeycomb](https://www.honeycomb.io/blog/engineering-levels-at-honeycomb)
 - [InfraCloud](https://career-ladders.infracloud.io/docs/)
+- [Inviqa](https://progression.invi.qa/)
 - [Khan Academy](https://docs.google.com/document/d/1qr0d05X5-AsyDYqKRCfgGGcWSshTMd_vfTggfhDpbls/edit)
 - [Kickstarter](https://gist.github.com/jamtur01/aef437a79fee5a9cefdc)
 - [Malt](https://malt.engineering/pages/career-path/engineering/)
 - [Medium](https://medium.com/s/engineering-growth-framework)
+- [Meetup](https://github.com/pensiero/meetup-engineering-roles)
 - [Mercari](https://engineering.mercari.com/en/ladder/)
 - [Monzo](https://monzo.com/documents/engineering-progression-framework-v3-0.pdf)
 - [Rent the Runway](https://dresscode.renttherunway.com/blog/ladder)
 - [Skylight](https://skylight.digital/careers/career-pathways/software-engineer/)
 - [Songkick](https://www.songkick.com/downloads/growth-framework/sk-growth-framework.pdf)
+- [Sourcegraph](https://sourcegraph.notion.site/Leveling-Guide-0e1b5c76ada64b9caac387f8b7c4fc66)
 - [Soundcloud](https://developers.soundcloud.com/blog/engineering-levels)
 - [Spotify](https://engineering.atspotify.com/2016/2/spotify-technology-career-steps)
 - [Square](https://developer.squareup.com/blog/squares-updated-growth-framework-for-engineers-and-engineering-managers/)
+- [Thumbtack](https://docs.google.com/spreadsheets/d/15ACBs-crUHnqf1wANUQwX9oZIDOi5tvJJXGWpKTcf00/edit)
+- [Wise](https://wise.jobs/engineering-career-map)
 
 ## Engineering Ladder Collections
 
@@ -42,6 +51,9 @@ A collection of engineering career ladders for reference and inspiration.
 - [Evolving the One Medical Leveling Guide](https://medium.com/one-medical-technology/evolving-the-one-medical-leveling-guide-51dc82d7e26c) &mdash; process for updating and evolving career ladders over time
 - [Engineering Ladders](https://github.com/jorgef/engineeringladders) &mdash; A framework for Engineering Managers
 - [The Software Engineering Job Ladder](https://cgroom.medium.com/the-software-engineering-job-ladder-4bf70b4c24f3) &mdash; Blog post by Chuck Groom
+- [Writing an Engineering Leveling Guide](https://stytch.com/blog/engineering-levels/) &mdash; Practical guide by Stytch for approaching building a career ladder
+- [10 Years of Engineering Ladders](https://skamille.medium.com/10-years-of-engineering-ladders-329d309000cd) &mdash; Retrospective by Camille Fournier on how public ladders evolved
+- [Principal Engineering at Zalando](https://engineering.zalando.com/posts/2022/02/principal-engineering-at-zalando.html) &mdash; Principal engineer archetypes and senior-level progression
 
 ## Engineering Management
 


### PR DESCRIPTION
## Summary

- Add 9 new engineering ladder links: Capgemini, Financial Times, Foursquare, Honeycomb, Inviqa, Meetup, Sourcegraph, Thumbtack, Wise
- Add 3 new resources: Stytch leveling guide, Camille Fournier retrospective, Zalando principal engineering
- Fix alphabetical ordering of existing entries (GitLab, Glossier, Fog Creek)
